### PR TITLE
feat: Sprint 3 — Mod Executors + Integration Registry

### DIFF
--- a/exoskull-app/app/api/rigs/route.ts
+++ b/exoskull-app/app/api/rigs/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { RIG_DEFINITIONS } from "@/lib/rigs";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/rigs — List all available rigs + user connection status
+ */
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Fetch user's rig connections
+    const { data: connections, error } = await supabase
+      .from("exo_rig_connections")
+      .select("rig_slug, sync_status, last_sync_at, created_at, metadata")
+      .eq("tenant_id", user.id);
+
+    if (error) {
+      console.error("[RigsAPI] Connections fetch error:", error);
+    }
+
+    const connectionMap = new Map(
+      (connections || []).map((c) => [c.rig_slug, c]),
+    );
+
+    // Build rig list with connection status
+    const rigs = Object.values(RIG_DEFINITIONS).map((rig) => {
+      const conn = connectionMap.get(rig.slug);
+      const connected = conn?.sync_status === "success";
+      const connectedAt =
+        conn?.metadata?.connected_at || conn?.created_at || null;
+
+      return {
+        slug: rig.slug,
+        name: rig.name,
+        description: rig.description,
+        icon: rig.icon,
+        category: rig.category,
+        connected,
+        sync_status: conn?.sync_status || null,
+        last_sync_at: conn?.last_sync_at || null,
+        connected_at: connectedAt,
+        has_oauth: !!rig.oauth,
+      };
+    });
+
+    return NextResponse.json({
+      rigs,
+      total: rigs.length,
+      connected: rigs.filter((r) => r.connected).length,
+    });
+  } catch (error) {
+    console.error("[RigsAPI] Error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/exoskull-app/app/dashboard/settings/integrations/page.tsx
+++ b/exoskull-app/app/dashboard/settings/integrations/page.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Loader2,
+  CheckCircle2,
+  Circle,
+  ExternalLink,
+  RefreshCw,
+  Plug,
+} from "lucide-react";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface RigInfo {
+  slug: string;
+  name: string;
+  description: string;
+  icon: string;
+  category: string;
+  connected: boolean;
+  sync_status: string | null;
+  last_sync_at: string | null;
+  connected_at: string | null;
+  has_oauth: boolean;
+}
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const CATEGORY_LABELS: Record<string, string> = {
+  health: "Zdrowie",
+  productivity: "Produktywnosc",
+  finance: "Finanse",
+  social: "Social",
+  smart_home: "Smart Home",
+};
+
+const CATEGORY_ORDER = [
+  "health",
+  "productivity",
+  "finance",
+  "social",
+  "smart_home",
+];
+
+// ============================================================================
+// COMPONENT
+// ============================================================================
+
+export default function IntegrationsPage() {
+  const [rigs, setRigs] = useState<RigInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [connecting, setConnecting] = useState<string | null>(null);
+
+  const fetchRigs = useCallback(async () => {
+    try {
+      const res = await fetch("/api/rigs");
+      const data = await res.json();
+      setRigs(data.rigs || []);
+    } catch (error) {
+      console.error("[Integrations] Fetch error:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRigs();
+  }, [fetchRigs]);
+
+  const handleConnect = async (slug: string) => {
+    setConnecting(slug);
+    // Redirect to OAuth flow
+    window.location.href = `/api/rigs/${slug}/connect`;
+  };
+
+  const connectedRigs = rigs.filter((r) => r.connected);
+  const availableRigs = rigs.filter((r) => !r.connected);
+
+  // Group by category
+  const groupedAvailable = CATEGORY_ORDER.reduce(
+    (acc, cat) => {
+      const items = availableRigs.filter((r) => r.category === cat);
+      if (items.length > 0) acc[cat] = items;
+      return acc;
+    },
+    {} as Record<string, RigInfo[]>,
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold">Integracje</h1>
+        <p className="text-muted-foreground">
+          Polacz zewnetrzne serwisy z ExoSkull
+        </p>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 gap-4">
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-lg bg-green-100 dark:bg-green-900/30">
+                <CheckCircle2 className="w-5 h-5 text-green-600 dark:text-green-400" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{connectedRigs.length}</p>
+                <p className="text-sm text-muted-foreground">Polaczone</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/30">
+                <Plug className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{rigs.length}</p>
+                <p className="text-sm text-muted-foreground">Dostepne</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Connected */}
+      {connectedRigs.length > 0 && (
+        <div className="space-y-3">
+          <h2 className="text-lg font-semibold">Polaczone</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {connectedRigs.map((rig) => (
+              <Card key={rig.slug}>
+                <CardContent className="p-4">
+                  <div className="flex items-start justify-between">
+                    <div className="flex items-center gap-3">
+                      <span className="text-2xl">{rig.icon}</span>
+                      <div>
+                        <h3 className="font-medium">{rig.name}</h3>
+                        <p className="text-sm text-muted-foreground line-clamp-1">
+                          {rig.description}
+                        </p>
+                      </div>
+                    </div>
+                    <Badge
+                      variant="outline"
+                      className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400 border-0 shrink-0"
+                    >
+                      <CheckCircle2 className="w-3 h-3 mr-1" />
+                      On
+                    </Badge>
+                  </div>
+                  <div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
+                    <span>
+                      {rig.last_sync_at
+                        ? `Sync: ${new Date(rig.last_sync_at).toLocaleDateString("pl-PL")}`
+                        : "Brak sync"}
+                    </span>
+                    <Badge variant="outline" className="text-xs border-0">
+                      {CATEGORY_LABELS[rig.category] || rig.category}
+                    </Badge>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Available by category */}
+      {Object.entries(groupedAvailable).map(([category, categoryRigs]) => (
+        <div key={category} className="space-y-3">
+          <h2 className="text-lg font-semibold">
+            {CATEGORY_LABELS[category] || category}
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {categoryRigs.map((rig) => (
+              <Card key={rig.slug}>
+                <CardContent className="p-4">
+                  <div className="flex items-start gap-3">
+                    <span className="text-2xl">{rig.icon}</span>
+                    <div className="flex-1 min-w-0">
+                      <h3 className="font-medium">{rig.name}</h3>
+                      <p className="text-sm text-muted-foreground line-clamp-2">
+                        {rig.description}
+                      </p>
+                    </div>
+                  </div>
+                  {rig.has_oauth ? (
+                    <Button
+                      size="sm"
+                      className="w-full mt-3"
+                      disabled={connecting === rig.slug}
+                      onClick={() => handleConnect(rig.slug)}
+                    >
+                      {connecting === rig.slug ? (
+                        <>
+                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                          Laczenie...
+                        </>
+                      ) : (
+                        <>
+                          <ExternalLink className="w-4 h-4 mr-2" />
+                          Polacz
+                        </>
+                      )}
+                    </Button>
+                  ) : (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="w-full mt-3"
+                      disabled
+                    >
+                      <Circle className="w-4 h-4 mr-2" />
+                      Wkrotce
+                    </Button>
+                  )}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      ))}
+
+      {/* Empty */}
+      {rigs.length === 0 && (
+        <Card>
+          <CardContent className="p-8 text-center">
+            <Plug className="w-12 h-12 mx-auto mb-4 text-muted-foreground" />
+            <h3 className="text-lg font-medium mb-2">Brak integracji</h3>
+            <p className="text-muted-foreground">
+              Integracje pojawia sie wkrotce.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/exoskull-app/components/dashboard/CollapsibleSidebar.tsx
+++ b/exoskull-app/components/dashboard/CollapsibleSidebar.tsx
@@ -2,7 +2,14 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Home, MessageSquare, Package, Brain, Settings } from "lucide-react";
+import {
+  Home,
+  MessageSquare,
+  Package,
+  Brain,
+  Plug,
+  Settings,
+} from "lucide-react";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 
 // ============================================================================
@@ -13,6 +20,7 @@ const NAV_ITEMS = [
   { href: "/dashboard", label: "Home", icon: Home },
   { href: "/dashboard/chat", label: "Chat", icon: MessageSquare },
   { href: "/dashboard/mods", label: "Mody", icon: Package },
+  { href: "/dashboard/settings/integrations", label: "Integracje", icon: Plug },
   { href: "/dashboard/memory", label: "Pamiec", icon: Brain },
   { href: "/dashboard/settings", label: "Ustawienia", icon: Settings },
 ];

--- a/exoskull-app/lib/mods/executors/exercise-logger.ts
+++ b/exoskull-app/lib/mods/executors/exercise-logger.ts
@@ -1,0 +1,335 @@
+// =====================================================
+// EXERCISE LOGGER MOD EXECUTOR
+// Log workouts: type, activity, duration, intensity
+// Uses generic exo_mod_data table
+// =====================================================
+
+import { IModExecutor, ModInsight, ModAction, ModSlug } from "../types";
+import { getServiceSupabase } from "@/lib/supabase/service";
+
+// =====================================================
+// Types
+// =====================================================
+
+interface ExerciseEntry {
+  type: "strength" | "cardio" | "flexibility" | "sports" | "other";
+  activity: string;
+  duration_minutes: number;
+  intensity: number; // 1-10
+  calories_burned?: number;
+  notes?: string;
+}
+
+interface ExerciseStats {
+  total_workouts: number;
+  total_minutes: number;
+  avg_intensity: number;
+  avg_duration: number;
+  top_activities: { activity: string; count: number }[];
+  weekly_goal_met: boolean;
+}
+
+const EXERCISE_TYPES = [
+  "strength",
+  "cardio",
+  "flexibility",
+  "sports",
+  "other",
+] as const;
+
+// =====================================================
+// Executor
+// =====================================================
+
+export class ExerciseLoggerExecutor implements IModExecutor {
+  readonly slug: ModSlug = "exercise-logger";
+
+  async getData(tenantId: string): Promise<Record<string, unknown>> {
+    try {
+      const now = new Date();
+      const weekAgo = new Date(
+        now.getTime() - 7 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      const monthAgo = new Date(
+        now.getTime() - 30 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+
+      const { data: entries, error } = await getServiceSupabase()
+        .from("exo_mod_data")
+        .select("*")
+        .eq("tenant_id", tenantId)
+        .eq("mod_slug", "exercise-logger")
+        .gte("created_at", monthAgo)
+        .order("created_at", { ascending: false });
+
+      if (error) {
+        console.error("[ExerciseLogger] Fetch error:", error);
+        throw error;
+      }
+
+      const all = (entries || []).map((e) => ({
+        id: e.id,
+        ...(e.data as ExerciseEntry),
+        created_at: e.created_at,
+      }));
+
+      const weekly = all.filter((e) => e.created_at >= weekAgo);
+      const weeklyStats = this.calculateStats(weekly, 150);
+
+      return {
+        recent: all.slice(0, 10),
+        weekly: { entries: weekly, stats: weeklyStats },
+        monthly: { entries: all, stats: this.calculateStats(all, 150) },
+      };
+    } catch (error) {
+      console.error("[ExerciseLogger] getData error:", error);
+      return {
+        recent: [],
+        weekly: { entries: [], stats: null },
+        monthly: { entries: [], stats: null },
+      };
+    }
+  }
+
+  async getInsights(tenantId: string): Promise<ModInsight[]> {
+    const insights: ModInsight[] = [];
+    const now = new Date();
+
+    try {
+      const data = await this.getData(tenantId);
+      const weeklyStats = (data.weekly as { stats: ExerciseStats | null })
+        ?.stats;
+
+      if (!weeklyStats || weeklyStats.total_workouts === 0) {
+        insights.push({
+          type: "info",
+          title: "Start Moving",
+          message:
+            "No workouts logged this week. Try a quick 20-minute session!",
+          action: {
+            label: "Log Workout",
+            type: "button",
+            onClick: "log_exercise",
+          },
+          created_at: now.toISOString(),
+        });
+        return insights;
+      }
+
+      if (weeklyStats.weekly_goal_met) {
+        insights.push({
+          type: "success",
+          title: "Goal Met!",
+          message: `${weeklyStats.total_minutes} minutes of exercise this week. Great job!`,
+          created_at: now.toISOString(),
+        });
+      } else {
+        const remaining = 150 - weeklyStats.total_minutes;
+        insights.push({
+          type: "info",
+          title: "Keep Going",
+          message: `${weeklyStats.total_minutes}/150 minutes this week. ${remaining} more to hit your goal.`,
+          created_at: now.toISOString(),
+        });
+      }
+
+      if (weeklyStats.avg_intensity >= 7) {
+        insights.push({
+          type: "warning",
+          title: "High Intensity",
+          message:
+            "Your average intensity is high. Make sure to include rest days.",
+          created_at: now.toISOString(),
+        });
+      }
+
+      if (weeklyStats.top_activities.length === 1) {
+        insights.push({
+          type: "info",
+          title: "Mix It Up",
+          message: `You've only done ${weeklyStats.top_activities[0].activity}. Try adding variety for balanced fitness.`,
+          created_at: now.toISOString(),
+        });
+      }
+
+      return insights;
+    } catch (error) {
+      console.error("[ExerciseLogger] getInsights error:", error);
+      return [
+        {
+          type: "warning",
+          title: "Error",
+          message: "Could not generate insights.",
+          created_at: now.toISOString(),
+        },
+      ];
+    }
+  }
+
+  async executeAction(
+    tenantId: string,
+    action: string,
+    params: Record<string, unknown>,
+  ): Promise<{ success: boolean; result?: unknown; error?: string }> {
+    try {
+      switch (action) {
+        case "log_exercise": {
+          const entry: ExerciseEntry = {
+            type: (params.type as ExerciseEntry["type"]) || "other",
+            activity: (params.activity as string) || "workout",
+            duration_minutes: (params.duration_minutes as number) || 30,
+            intensity: Math.min(
+              10,
+              Math.max(1, (params.intensity as number) || 5),
+            ),
+            calories_burned: params.calories_burned as number | undefined,
+            notes: params.notes as string | undefined,
+          };
+
+          const { data, error } = await getServiceSupabase()
+            .from("exo_mod_data")
+            .insert({
+              tenant_id: tenantId,
+              mod_slug: "exercise-logger",
+              data: entry,
+            })
+            .select()
+            .single();
+
+          if (error) return { success: false, error: error.message };
+          return {
+            success: true,
+            result: {
+              entry: data,
+              message: `Logged ${entry.activity} (${entry.duration_minutes} min)`,
+            },
+          };
+        }
+
+        case "get_history": {
+          const days = (params.days as number) || 30;
+          const since = new Date(
+            Date.now() - days * 24 * 60 * 60 * 1000,
+          ).toISOString();
+
+          const { data, error } = await getServiceSupabase()
+            .from("exo_mod_data")
+            .select("*")
+            .eq("tenant_id", tenantId)
+            .eq("mod_slug", "exercise-logger")
+            .gte("created_at", since)
+            .order("created_at", { ascending: false });
+
+          if (error) return { success: false, error: error.message };
+          return {
+            success: true,
+            result: { entries: data || [], count: data?.length || 0 },
+          };
+        }
+
+        default:
+          return { success: false, error: `Unknown action: ${action}` };
+      }
+    } catch (error) {
+      console.error("[ExerciseLogger] executeAction error:", error);
+      return { success: false, error: (error as Error).message };
+    }
+  }
+
+  getActions(): ModAction[] {
+    return [
+      {
+        slug: "log_exercise",
+        name: "Log Exercise",
+        description: "Record a workout session",
+        params_schema: {
+          type: "object",
+          required: ["activity", "duration_minutes"],
+          properties: {
+            type: {
+              type: "string",
+              enum: EXERCISE_TYPES,
+              description: "Exercise category",
+            },
+            activity: {
+              type: "string",
+              description: "Specific activity (e.g. running, bench press)",
+            },
+            duration_minutes: {
+              type: "number",
+              description: "Duration in minutes",
+            },
+            intensity: {
+              type: "number",
+              minimum: 1,
+              maximum: 10,
+              description: "Intensity 1-10",
+            },
+            calories_burned: {
+              type: "number",
+              description: "Estimated calories burned",
+            },
+            notes: { type: "string", description: "Optional notes" },
+          },
+        },
+      },
+      {
+        slug: "get_history",
+        name: "Get History",
+        description: "Get exercise history",
+        params_schema: {
+          type: "object",
+          properties: {
+            days: {
+              type: "number",
+              default: 30,
+              description: "Days to look back",
+            },
+          },
+        },
+      },
+    ];
+  }
+
+  private calculateStats(
+    entries: {
+      duration_minutes: number;
+      intensity: number;
+      activity: string;
+    }[],
+    weeklyGoalMinutes: number,
+  ): ExerciseStats {
+    if (entries.length === 0) {
+      return {
+        total_workouts: 0,
+        total_minutes: 0,
+        avg_intensity: 0,
+        avg_duration: 0,
+        top_activities: [],
+        weekly_goal_met: false,
+      };
+    }
+
+    const totalMinutes = entries.reduce((s, e) => s + e.duration_minutes, 0);
+    const avgIntensity =
+      entries.reduce((s, e) => s + e.intensity, 0) / entries.length;
+
+    const activityCounts: Record<string, number> = {};
+    for (const e of entries) {
+      activityCounts[e.activity] = (activityCounts[e.activity] || 0) + 1;
+    }
+    const topActivities = Object.entries(activityCounts)
+      .map(([activity, count]) => ({ activity, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5);
+
+    return {
+      total_workouts: entries.length,
+      total_minutes: totalMinutes,
+      avg_intensity: Math.round(avgIntensity * 10) / 10,
+      avg_duration: Math.round(totalMinutes / entries.length),
+      top_activities: topActivities,
+      weekly_goal_met: totalMinutes >= weeklyGoalMinutes,
+    };
+  }
+}

--- a/exoskull-app/lib/mods/executors/food-logger.ts
+++ b/exoskull-app/lib/mods/executors/food-logger.ts
@@ -1,0 +1,307 @@
+// =====================================================
+// FOOD LOGGER MOD EXECUTOR
+// Track meals, calories, macronutrients
+// Uses generic exo_mod_data table
+// =====================================================
+
+import { IModExecutor, ModInsight, ModAction, ModSlug } from "../types";
+import { getServiceSupabase } from "@/lib/supabase/service";
+
+// =====================================================
+// Types
+// =====================================================
+
+interface FoodEntry {
+  meal_type: "breakfast" | "lunch" | "dinner" | "snack";
+  description: string;
+  calories?: number;
+  protein_g?: number;
+  carbs_g?: number;
+  fat_g?: number;
+  notes?: string;
+}
+
+interface FoodStats {
+  total_meals: number;
+  avg_daily_calories: number | null;
+  total_calories: number;
+  meals_by_type: Record<string, number>;
+  days_tracked: number;
+}
+
+const MEAL_TYPES = ["breakfast", "lunch", "dinner", "snack"] as const;
+
+// =====================================================
+// Executor
+// =====================================================
+
+export class FoodLoggerExecutor implements IModExecutor {
+  readonly slug: ModSlug = "food-logger";
+
+  async getData(tenantId: string): Promise<Record<string, unknown>> {
+    try {
+      const now = new Date();
+      const today = now.toISOString().split("T")[0];
+      const weekAgo = new Date(
+        now.getTime() - 7 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+
+      const { data: entries, error } = await getServiceSupabase()
+        .from("exo_mod_data")
+        .select("*")
+        .eq("tenant_id", tenantId)
+        .eq("mod_slug", "food-logger")
+        .gte("created_at", weekAgo)
+        .order("created_at", { ascending: false });
+
+      if (error) {
+        console.error("[FoodLogger] Fetch error:", error);
+        throw error;
+      }
+
+      const all = (entries || []).map((e) => ({
+        id: e.id,
+        ...(e.data as FoodEntry),
+        created_at: e.created_at,
+      }));
+
+      const todayEntries = all.filter((e) => e.created_at.startsWith(today));
+      const todayCalories = todayEntries.reduce(
+        (s, e) => s + (e.calories || 0),
+        0,
+      );
+
+      return {
+        today: {
+          entries: todayEntries,
+          total_calories: todayCalories,
+          meals_logged: todayEntries.length,
+        },
+        weekly: { entries: all, stats: this.calculateStats(all) },
+      };
+    } catch (error) {
+      console.error("[FoodLogger] getData error:", error);
+      return {
+        today: { entries: [], total_calories: 0, meals_logged: 0 },
+        weekly: { entries: [], stats: null },
+      };
+    }
+  }
+
+  async getInsights(tenantId: string): Promise<ModInsight[]> {
+    const insights: ModInsight[] = [];
+    const now = new Date();
+
+    try {
+      const data = await this.getData(tenantId);
+      const today = data.today as {
+        meals_logged: number;
+        total_calories: number;
+      };
+      const stats = (data.weekly as { stats: FoodStats | null })?.stats;
+
+      if (today.meals_logged === 0) {
+        insights.push({
+          type: "info",
+          title: "Log Your Meals",
+          message:
+            "No meals logged today. Track what you eat for better insights!",
+          action: { label: "Log Meal", type: "button", onClick: "log_meal" },
+          created_at: now.toISOString(),
+        });
+      } else if (today.total_calories > 0) {
+        const remaining = 2000 - today.total_calories;
+        if (remaining > 0) {
+          insights.push({
+            type: "info",
+            title: "Today's Intake",
+            message: `${today.total_calories} kcal logged today. ~${remaining} kcal remaining.`,
+            created_at: now.toISOString(),
+          });
+        } else {
+          insights.push({
+            type: "warning",
+            title: "Calorie Goal Reached",
+            message: `${today.total_calories} kcal today — you've hit your daily target.`,
+            created_at: now.toISOString(),
+          });
+        }
+      }
+
+      if (stats && stats.days_tracked >= 3) {
+        if (stats.avg_daily_calories && stats.avg_daily_calories < 1500) {
+          insights.push({
+            type: "warning",
+            title: "Low Calorie Intake",
+            message: `Averaging ${Math.round(stats.avg_daily_calories)} kcal/day. Make sure you're eating enough.`,
+            created_at: now.toISOString(),
+          });
+        }
+
+        const mealTypes = Object.keys(stats.meals_by_type);
+        if (!mealTypes.includes("breakfast") && stats.total_meals > 5) {
+          insights.push({
+            type: "info",
+            title: "Missing Breakfast",
+            message:
+              "You rarely log breakfast. A morning meal can boost energy and focus.",
+            created_at: now.toISOString(),
+          });
+        }
+      }
+
+      return insights;
+    } catch (error) {
+      console.error("[FoodLogger] getInsights error:", error);
+      return [
+        {
+          type: "warning",
+          title: "Error",
+          message: "Could not generate insights.",
+          created_at: now.toISOString(),
+        },
+      ];
+    }
+  }
+
+  async executeAction(
+    tenantId: string,
+    action: string,
+    params: Record<string, unknown>,
+  ): Promise<{ success: boolean; result?: unknown; error?: string }> {
+    try {
+      switch (action) {
+        case "log_meal": {
+          const entry: FoodEntry = {
+            meal_type: (params.meal_type as FoodEntry["meal_type"]) || "snack",
+            description: (params.description as string) || "meal",
+            calories: params.calories as number | undefined,
+            protein_g: params.protein_g as number | undefined,
+            carbs_g: params.carbs_g as number | undefined,
+            fat_g: params.fat_g as number | undefined,
+            notes: params.notes as string | undefined,
+          };
+
+          const { data, error } = await getServiceSupabase()
+            .from("exo_mod_data")
+            .insert({
+              tenant_id: tenantId,
+              mod_slug: "food-logger",
+              data: entry,
+            })
+            .select()
+            .single();
+
+          if (error) return { success: false, error: error.message };
+          return {
+            success: true,
+            result: {
+              entry: data,
+              message: `Logged ${entry.meal_type}: ${entry.description}`,
+            },
+          };
+        }
+
+        case "get_history": {
+          const days = (params.days as number) || 7;
+          const since = new Date(
+            Date.now() - days * 24 * 60 * 60 * 1000,
+          ).toISOString();
+
+          const { data, error } = await getServiceSupabase()
+            .from("exo_mod_data")
+            .select("*")
+            .eq("tenant_id", tenantId)
+            .eq("mod_slug", "food-logger")
+            .gte("created_at", since)
+            .order("created_at", { ascending: false });
+
+          if (error) return { success: false, error: error.message };
+          return {
+            success: true,
+            result: { entries: data || [], count: data?.length || 0 },
+          };
+        }
+
+        default:
+          return { success: false, error: `Unknown action: ${action}` };
+      }
+    } catch (error) {
+      console.error("[FoodLogger] executeAction error:", error);
+      return { success: false, error: (error as Error).message };
+    }
+  }
+
+  getActions(): ModAction[] {
+    return [
+      {
+        slug: "log_meal",
+        name: "Log Meal",
+        description: "Record a meal or snack",
+        params_schema: {
+          type: "object",
+          required: ["description"],
+          properties: {
+            meal_type: {
+              type: "string",
+              enum: MEAL_TYPES,
+              description: "Meal type",
+            },
+            description: { type: "string", description: "What you ate" },
+            calories: { type: "number", description: "Estimated calories" },
+            protein_g: { type: "number", description: "Protein in grams" },
+            carbs_g: { type: "number", description: "Carbs in grams" },
+            fat_g: { type: "number", description: "Fat in grams" },
+            notes: { type: "string", description: "Optional notes" },
+          },
+        },
+      },
+      {
+        slug: "get_history",
+        name: "Get History",
+        description: "Get food log history",
+        params_schema: {
+          type: "object",
+          properties: {
+            days: {
+              type: "number",
+              default: 7,
+              description: "Days to look back",
+            },
+          },
+        },
+      },
+    ];
+  }
+
+  private calculateStats(
+    entries: (FoodEntry & { created_at: string })[],
+  ): FoodStats {
+    if (entries.length === 0) {
+      return {
+        total_meals: 0,
+        avg_daily_calories: null,
+        total_calories: 0,
+        meals_by_type: {},
+        days_tracked: 0,
+      };
+    }
+
+    const totalCalories = entries.reduce((s, e) => s + (e.calories || 0), 0);
+    const days = new Set(entries.map((e) => e.created_at.split("T")[0]));
+
+    const mealsByType: Record<string, number> = {};
+    for (const e of entries) {
+      mealsByType[e.meal_type] = (mealsByType[e.meal_type] || 0) + 1;
+    }
+
+    return {
+      total_meals: entries.length,
+      avg_daily_calories:
+        days.size > 0 ? Math.round(totalCalories / days.size) : null,
+      total_calories: totalCalories,
+      meals_by_type: mealsByType,
+      days_tracked: days.size,
+    };
+  }
+}

--- a/exoskull-app/lib/mods/executors/index.ts
+++ b/exoskull-app/lib/mods/executors/index.ts
@@ -9,6 +9,11 @@ import { MoodTrackerExecutor } from "./mood-tracker";
 import { HabitTrackerExecutor } from "./habit-tracker";
 import { SleepTrackerExecutor } from "./sleep-tracker";
 import { ActivityTrackerExecutor } from "./activity-tracker";
+import { ExerciseLoggerExecutor } from "./exercise-logger";
+import { FoodLoggerExecutor } from "./food-logger";
+import { WaterTrackerExecutor } from "./water-tracker";
+import { SocialTrackerExecutor } from "./social-tracker";
+import { JournalExecutor } from "./journal";
 import {
   getDynamicSkillExecutor,
   hasDynamicSkill,
@@ -31,13 +36,38 @@ export function createActivityTrackerExecutor(): IModExecutor {
   return new ActivityTrackerExecutor();
 }
 
+export function createExerciseLoggerExecutor(): IModExecutor {
+  return new ExerciseLoggerExecutor();
+}
+
+export function createFoodLoggerExecutor(): IModExecutor {
+  return new FoodLoggerExecutor();
+}
+
+export function createWaterTrackerExecutor(): IModExecutor {
+  return new WaterTrackerExecutor();
+}
+
+export function createSocialTrackerExecutor(): IModExecutor {
+  return new SocialTrackerExecutor();
+}
+
+export function createJournalExecutor(): IModExecutor {
+  return new JournalExecutor();
+}
+
 // Registry of all static (bundled) mod executors
 const EXECUTORS: Partial<Record<BuiltinModSlug, () => IModExecutor>> = {
   "task-manager": createTaskManagerExecutor,
   "mood-tracker": createMoodTrackerExecutor,
   "habit-tracker": createHabitTrackerExecutor,
   "sleep-tracker": createSleepTrackerExecutor,
-  "energy-monitor": createActivityTrackerExecutor, // Activity tracker uses energy-monitor slug
+  "energy-monitor": createActivityTrackerExecutor,
+  "exercise-logger": createExerciseLoggerExecutor,
+  "food-logger": createFoodLoggerExecutor,
+  "water-tracker": createWaterTrackerExecutor,
+  "social-tracker": createSocialTrackerExecutor,
+  journal: createJournalExecutor,
 };
 
 /**
@@ -97,3 +127,8 @@ export { MoodTrackerExecutor };
 export { HabitTrackerExecutor };
 export { SleepTrackerExecutor };
 export { ActivityTrackerExecutor };
+export { ExerciseLoggerExecutor };
+export { FoodLoggerExecutor };
+export { WaterTrackerExecutor };
+export { SocialTrackerExecutor };
+export { JournalExecutor };

--- a/exoskull-app/lib/mods/executors/journal.ts
+++ b/exoskull-app/lib/mods/executors/journal.ts
@@ -1,0 +1,365 @@
+// =====================================================
+// JOURNAL MOD EXECUTOR
+// Daily journaling with mood tagging and reflection
+// Uses generic exo_mod_data table
+// =====================================================
+
+import { IModExecutor, ModInsight, ModAction, ModSlug } from "../types";
+import { getServiceSupabase } from "@/lib/supabase/service";
+
+// =====================================================
+// Types
+// =====================================================
+
+interface JournalEntry {
+  title?: string;
+  content: string;
+  mood?: number; // 1-10
+  tags?: string[];
+}
+
+interface JournalStats {
+  total_entries: number;
+  avg_mood: number | null;
+  days_with_entries: number;
+  top_tags: { tag: string; count: number }[];
+  streak: number;
+}
+
+// =====================================================
+// Executor
+// =====================================================
+
+export class JournalExecutor implements IModExecutor {
+  readonly slug: ModSlug = "journal";
+
+  async getData(tenantId: string): Promise<Record<string, unknown>> {
+    try {
+      const now = new Date();
+      const monthAgo = new Date(
+        now.getTime() - 30 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+
+      const { data: entries, error } = await getServiceSupabase()
+        .from("exo_mod_data")
+        .select("*")
+        .eq("tenant_id", tenantId)
+        .eq("mod_slug", "journal")
+        .gte("created_at", monthAgo)
+        .order("created_at", { ascending: false });
+
+      if (error) {
+        console.error("[Journal] Fetch error:", error);
+        throw error;
+      }
+
+      const all = (entries || []).map((e) => ({
+        id: e.id,
+        ...(e.data as JournalEntry),
+        created_at: e.created_at,
+      }));
+
+      return {
+        recent: all.slice(0, 5),
+        monthly: { entries: all, stats: this.calculateStats(all) },
+      };
+    } catch (error) {
+      console.error("[Journal] getData error:", error);
+      return { recent: [], monthly: { entries: [], stats: null } };
+    }
+  }
+
+  async getInsights(tenantId: string): Promise<ModInsight[]> {
+    const insights: ModInsight[] = [];
+    const now = new Date();
+
+    try {
+      const data = await this.getData(tenantId);
+      const stats = (data.monthly as { stats: JournalStats | null })?.stats;
+      const today = now.toISOString().split("T")[0];
+      const recent = data.recent as { created_at: string }[];
+      const wrotToday = recent.some((e) => e.created_at.startsWith(today));
+
+      if (!wrotToday) {
+        insights.push({
+          type: "info",
+          title: "Write Today",
+          message: "You haven't journaled today. Take a moment to reflect.",
+          action: {
+            label: "Write Entry",
+            type: "button",
+            onClick: "write_entry",
+          },
+          created_at: now.toISOString(),
+        });
+      }
+
+      if (stats) {
+        if (stats.streak >= 7) {
+          insights.push({
+            type: "success",
+            title: "Writing Streak!",
+            message: `${stats.streak}-day journaling streak. Impressive consistency!`,
+            created_at: now.toISOString(),
+          });
+        } else if (stats.streak >= 3) {
+          insights.push({
+            type: "success",
+            title: "Building Habit",
+            message: `${stats.streak}-day streak. Keep going to build the habit!`,
+            created_at: now.toISOString(),
+          });
+        }
+
+        if (
+          stats.avg_mood !== null &&
+          stats.avg_mood < 4 &&
+          stats.total_entries >= 5
+        ) {
+          insights.push({
+            type: "warning",
+            title: "Low Mood Pattern",
+            message:
+              "Your journal mood ratings have been low. Consider talking to someone you trust.",
+            created_at: now.toISOString(),
+          });
+        }
+
+        if (stats.top_tags.length > 0) {
+          const topTag = stats.top_tags[0];
+          insights.push({
+            type: "info",
+            title: "Common Theme",
+            message: `"${topTag.tag}" appears most in your entries (${topTag.count} times).`,
+            data: { tags: stats.top_tags },
+            created_at: now.toISOString(),
+          });
+        }
+      }
+
+      return insights;
+    } catch (error) {
+      console.error("[Journal] getInsights error:", error);
+      return [
+        {
+          type: "warning",
+          title: "Error",
+          message: "Could not generate insights.",
+          created_at: now.toISOString(),
+        },
+      ];
+    }
+  }
+
+  async executeAction(
+    tenantId: string,
+    action: string,
+    params: Record<string, unknown>,
+  ): Promise<{ success: boolean; result?: unknown; error?: string }> {
+    try {
+      switch (action) {
+        case "write_entry": {
+          const content = params.content as string;
+          if (!content || content.trim().length === 0) {
+            return { success: false, error: "Content is required" };
+          }
+
+          const entry: JournalEntry = {
+            title: params.title as string | undefined,
+            content: content.trim(),
+            mood: params.mood as number | undefined,
+            tags: params.tags as string[] | undefined,
+          };
+
+          const { data, error } = await getServiceSupabase()
+            .from("exo_mod_data")
+            .insert({ tenant_id: tenantId, mod_slug: "journal", data: entry })
+            .select()
+            .single();
+
+          if (error) return { success: false, error: error.message };
+          return {
+            success: true,
+            result: { entry: data, message: "Journal entry saved" },
+          };
+        }
+
+        case "get_entries": {
+          const days = (params.days as number) || 30;
+          const since = new Date(
+            Date.now() - days * 24 * 60 * 60 * 1000,
+          ).toISOString();
+
+          const { data, error } = await getServiceSupabase()
+            .from("exo_mod_data")
+            .select("*")
+            .eq("tenant_id", tenantId)
+            .eq("mod_slug", "journal")
+            .gte("created_at", since)
+            .order("created_at", { ascending: false });
+
+          if (error) return { success: false, error: error.message };
+          return {
+            success: true,
+            result: { entries: data || [], count: data?.length || 0 },
+          };
+        }
+
+        case "search": {
+          const query = (params.query as string) || "";
+          if (!query) return { success: false, error: "Search query required" };
+
+          const { data, error } = await getServiceSupabase()
+            .from("exo_mod_data")
+            .select("*")
+            .eq("tenant_id", tenantId)
+            .eq("mod_slug", "journal")
+            .order("created_at", { ascending: false })
+            .limit(50);
+
+          if (error) return { success: false, error: error.message };
+
+          const lowerQuery = query.toLowerCase();
+          const matches = (data || []).filter((e) => {
+            const d = e.data as JournalEntry;
+            return (
+              d.content.toLowerCase().includes(lowerQuery) ||
+              d.title?.toLowerCase().includes(lowerQuery) ||
+              d.tags?.some((t) => t.toLowerCase().includes(lowerQuery))
+            );
+          });
+
+          return {
+            success: true,
+            result: { entries: matches, count: matches.length },
+          };
+        }
+
+        default:
+          return { success: false, error: `Unknown action: ${action}` };
+      }
+    } catch (error) {
+      console.error("[Journal] executeAction error:", error);
+      return { success: false, error: (error as Error).message };
+    }
+  }
+
+  getActions(): ModAction[] {
+    return [
+      {
+        slug: "write_entry",
+        name: "Write Entry",
+        description: "Write a new journal entry",
+        params_schema: {
+          type: "object",
+          required: ["content"],
+          properties: {
+            title: { type: "string", description: "Optional title" },
+            content: { type: "string", description: "Journal content" },
+            mood: {
+              type: "number",
+              minimum: 1,
+              maximum: 10,
+              description: "Mood 1-10",
+            },
+            tags: {
+              type: "array",
+              items: { type: "string" },
+              description: "Tags for categorization",
+            },
+          },
+        },
+      },
+      {
+        slug: "get_entries",
+        name: "Get Entries",
+        description: "Get recent journal entries",
+        params_schema: {
+          type: "object",
+          properties: {
+            days: {
+              type: "number",
+              default: 30,
+              description: "Days to look back",
+            },
+          },
+        },
+      },
+      {
+        slug: "search",
+        name: "Search",
+        description: "Search journal entries by keyword",
+        params_schema: {
+          type: "object",
+          required: ["query"],
+          properties: {
+            query: { type: "string", description: "Search keyword" },
+          },
+        },
+      },
+    ];
+  }
+
+  private calculateStats(
+    entries: (JournalEntry & { created_at: string })[],
+  ): JournalStats {
+    if (entries.length === 0) {
+      return {
+        total_entries: 0,
+        avg_mood: null,
+        days_with_entries: 0,
+        top_tags: [],
+        streak: 0,
+      };
+    }
+
+    // Mood average
+    const moodEntries = entries.filter((e) => e.mood != null);
+    const avgMood =
+      moodEntries.length > 0
+        ? Math.round(
+            (moodEntries.reduce((s, e) => s + (e.mood || 0), 0) /
+              moodEntries.length) *
+              10,
+          ) / 10
+        : null;
+
+    // Days with entries
+    const days = new Set(entries.map((e) => e.created_at.split("T")[0]));
+
+    // Tags
+    const tagCounts: Record<string, number> = {};
+    for (const e of entries) {
+      for (const tag of e.tags || []) {
+        tagCounts[tag] = (tagCounts[tag] || 0) + 1;
+      }
+    }
+    const topTags = Object.entries(tagCounts)
+      .map(([tag, count]) => ({ tag, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5);
+
+    // Streak (consecutive days from today backwards)
+    const sortedDays = [...days].sort().reverse();
+    let streak = 0;
+    const today = new Date();
+    for (let i = 0; i < 60; i++) {
+      const checkDate = new Date(today.getTime() - i * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .split("T")[0];
+      if (sortedDays.includes(checkDate)) {
+        streak++;
+      } else if (i > 0) {
+        break;
+      }
+    }
+
+    return {
+      total_entries: entries.length,
+      avg_mood: avgMood,
+      days_with_entries: days.size,
+      top_tags: topTags,
+      streak,
+    };
+  }
+}

--- a/exoskull-app/lib/mods/executors/social-tracker.ts
+++ b/exoskull-app/lib/mods/executors/social-tracker.ts
@@ -1,0 +1,337 @@
+// =====================================================
+// SOCIAL TRACKER MOD EXECUTOR
+// Track social interactions and relationship health
+// Uses generic exo_mod_data table
+// =====================================================
+
+import { IModExecutor, ModInsight, ModAction, ModSlug } from "../types";
+import { getServiceSupabase } from "@/lib/supabase/service";
+
+// =====================================================
+// Types
+// =====================================================
+
+interface SocialEntry {
+  interaction_type: "in_person" | "call" | "video" | "text";
+  person: string;
+  duration_minutes?: number;
+  quality: number; // 1-10
+  notes?: string;
+}
+
+interface SocialStats {
+  total_interactions: number;
+  unique_people: number;
+  avg_quality: number;
+  interactions_by_type: Record<string, number>;
+  top_contacts: { person: string; count: number }[];
+  weekly_goal_met: boolean;
+}
+
+const INTERACTION_TYPES = ["in_person", "call", "video", "text"] as const;
+
+// =====================================================
+// Executor
+// =====================================================
+
+export class SocialTrackerExecutor implements IModExecutor {
+  readonly slug: ModSlug = "social-tracker";
+
+  async getData(tenantId: string): Promise<Record<string, unknown>> {
+    try {
+      const now = new Date();
+      const weekAgo = new Date(
+        now.getTime() - 7 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      const monthAgo = new Date(
+        now.getTime() - 30 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+
+      const { data: entries, error } = await getServiceSupabase()
+        .from("exo_mod_data")
+        .select("*")
+        .eq("tenant_id", tenantId)
+        .eq("mod_slug", "social-tracker")
+        .gte("created_at", monthAgo)
+        .order("created_at", { ascending: false });
+
+      if (error) {
+        console.error("[SocialTracker] Fetch error:", error);
+        throw error;
+      }
+
+      const all = (entries || []).map((e) => ({
+        id: e.id,
+        ...(e.data as SocialEntry),
+        created_at: e.created_at,
+      }));
+
+      const weekly = all.filter((e) => e.created_at >= weekAgo);
+
+      return {
+        recent: all.slice(0, 10),
+        weekly: { entries: weekly, stats: this.calculateStats(weekly, 5) },
+        monthly: { entries: all, stats: this.calculateStats(all, 20) },
+      };
+    } catch (error) {
+      console.error("[SocialTracker] getData error:", error);
+      return {
+        recent: [],
+        weekly: { entries: [], stats: null },
+        monthly: { entries: [], stats: null },
+      };
+    }
+  }
+
+  async getInsights(tenantId: string): Promise<ModInsight[]> {
+    const insights: ModInsight[] = [];
+    const now = new Date();
+
+    try {
+      const data = await this.getData(tenantId);
+      const weeklyStats = (data.weekly as { stats: SocialStats | null })?.stats;
+      const monthlyStats = (data.monthly as { stats: SocialStats | null })
+        ?.stats;
+
+      if (!weeklyStats || weeklyStats.total_interactions === 0) {
+        insights.push({
+          type: "warning",
+          title: "No Social Activity",
+          message: "No interactions logged this week. Reach out to someone!",
+          action: {
+            label: "Log Interaction",
+            type: "button",
+            onClick: "log_interaction",
+          },
+          created_at: now.toISOString(),
+        });
+        return insights;
+      }
+
+      if (weeklyStats.weekly_goal_met) {
+        insights.push({
+          type: "success",
+          title: "Social Goal Met",
+          message: `${weeklyStats.total_interactions} interactions this week. Great social health!`,
+          created_at: now.toISOString(),
+        });
+      } else {
+        const remaining = 5 - weeklyStats.total_interactions;
+        insights.push({
+          type: "info",
+          title: "Stay Connected",
+          message: `${weeklyStats.total_interactions}/5 interactions this week. ${remaining} more to hit your goal.`,
+          created_at: now.toISOString(),
+        });
+      }
+
+      if (weeklyStats.avg_quality < 5) {
+        insights.push({
+          type: "warning",
+          title: "Low Quality Interactions",
+          message:
+            "Your interaction quality has been low. Focus on deeper, more meaningful connections.",
+          created_at: now.toISOString(),
+        });
+      }
+
+      // Check for neglected contacts (monthly)
+      if (
+        monthlyStats &&
+        monthlyStats.unique_people <= 2 &&
+        monthlyStats.total_interactions >= 5
+      ) {
+        insights.push({
+          type: "info",
+          title: "Expand Your Circle",
+          message: `You've only interacted with ${monthlyStats.unique_people} people this month. Consider reconnecting with someone you haven't talked to.`,
+          created_at: now.toISOString(),
+        });
+      }
+
+      // In-person vs digital ratio
+      if (
+        weeklyStats.interactions_by_type.in_person === 0 &&
+        weeklyStats.total_interactions >= 3
+      ) {
+        insights.push({
+          type: "info",
+          title: "Go Offline",
+          message:
+            "All interactions this week were digital. Try meeting someone in person!",
+          created_at: now.toISOString(),
+        });
+      }
+
+      return insights;
+    } catch (error) {
+      console.error("[SocialTracker] getInsights error:", error);
+      return [
+        {
+          type: "warning",
+          title: "Error",
+          message: "Could not generate insights.",
+          created_at: now.toISOString(),
+        },
+      ];
+    }
+  }
+
+  async executeAction(
+    tenantId: string,
+    action: string,
+    params: Record<string, unknown>,
+  ): Promise<{ success: boolean; result?: unknown; error?: string }> {
+    try {
+      switch (action) {
+        case "log_interaction": {
+          const entry: SocialEntry = {
+            interaction_type:
+              (params.interaction_type as SocialEntry["interaction_type"]) ||
+              "text",
+            person: (params.person as string) || "someone",
+            duration_minutes: params.duration_minutes as number | undefined,
+            quality: Math.min(10, Math.max(1, (params.quality as number) || 7)),
+            notes: params.notes as string | undefined,
+          };
+
+          const { data, error } = await getServiceSupabase()
+            .from("exo_mod_data")
+            .insert({
+              tenant_id: tenantId,
+              mod_slug: "social-tracker",
+              data: entry,
+            })
+            .select()
+            .single();
+
+          if (error) return { success: false, error: error.message };
+          return {
+            success: true,
+            result: {
+              entry: data,
+              message: `Logged ${entry.interaction_type} with ${entry.person}`,
+            },
+          };
+        }
+
+        case "get_history": {
+          const days = (params.days as number) || 30;
+          const since = new Date(
+            Date.now() - days * 24 * 60 * 60 * 1000,
+          ).toISOString();
+
+          const { data, error } = await getServiceSupabase()
+            .from("exo_mod_data")
+            .select("*")
+            .eq("tenant_id", tenantId)
+            .eq("mod_slug", "social-tracker")
+            .gte("created_at", since)
+            .order("created_at", { ascending: false });
+
+          if (error) return { success: false, error: error.message };
+          return {
+            success: true,
+            result: { entries: data || [], count: data?.length || 0 },
+          };
+        }
+
+        default:
+          return { success: false, error: `Unknown action: ${action}` };
+      }
+    } catch (error) {
+      console.error("[SocialTracker] executeAction error:", error);
+      return { success: false, error: (error as Error).message };
+    }
+  }
+
+  getActions(): ModAction[] {
+    return [
+      {
+        slug: "log_interaction",
+        name: "Log Interaction",
+        description: "Record a social interaction",
+        params_schema: {
+          type: "object",
+          required: ["person"],
+          properties: {
+            interaction_type: {
+              type: "string",
+              enum: INTERACTION_TYPES,
+              description: "Type of interaction",
+            },
+            person: { type: "string", description: "Who you interacted with" },
+            duration_minutes: {
+              type: "number",
+              description: "Duration in minutes",
+            },
+            quality: {
+              type: "number",
+              minimum: 1,
+              maximum: 10,
+              description: "Quality 1-10",
+            },
+            notes: { type: "string", description: "Optional notes" },
+          },
+        },
+      },
+      {
+        slug: "get_history",
+        name: "Get History",
+        description: "Get social interaction history",
+        params_schema: {
+          type: "object",
+          properties: {
+            days: {
+              type: "number",
+              default: 30,
+              description: "Days to look back",
+            },
+          },
+        },
+      },
+    ];
+  }
+
+  private calculateStats(
+    entries: (SocialEntry & { created_at: string })[],
+    weeklyGoal: number,
+  ): SocialStats {
+    if (entries.length === 0) {
+      return {
+        total_interactions: 0,
+        unique_people: 0,
+        avg_quality: 0,
+        interactions_by_type: {},
+        top_contacts: [],
+        weekly_goal_met: false,
+      };
+    }
+
+    const avgQuality =
+      entries.reduce((s, e) => s + e.quality, 0) / entries.length;
+    const people = new Set(entries.map((e) => e.person.toLowerCase()));
+
+    const byType: Record<string, number> = {};
+    const personCounts: Record<string, number> = {};
+    for (const e of entries) {
+      byType[e.interaction_type] = (byType[e.interaction_type] || 0) + 1;
+      const key = e.person.toLowerCase();
+      personCounts[key] = (personCounts[key] || 0) + 1;
+    }
+
+    const topContacts = Object.entries(personCounts)
+      .map(([person, count]) => ({ person, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5);
+
+    return {
+      total_interactions: entries.length,
+      unique_people: people.size,
+      avg_quality: Math.round(avgQuality * 10) / 10,
+      interactions_by_type: byType,
+      top_contacts: topContacts,
+      weekly_goal_met: entries.length >= weeklyGoal,
+    };
+  }
+}

--- a/exoskull-app/lib/mods/executors/water-tracker.ts
+++ b/exoskull-app/lib/mods/executors/water-tracker.ts
@@ -1,0 +1,292 @@
+// =====================================================
+// WATER TRACKER MOD EXECUTOR
+// Track daily water intake, monitor hydration goals
+// Uses generic exo_mod_data table
+// =====================================================
+
+import { IModExecutor, ModInsight, ModAction, ModSlug } from "../types";
+import { getServiceSupabase } from "@/lib/supabase/service";
+
+// =====================================================
+// Types
+// =====================================================
+
+interface WaterEntry {
+  amount_ml: number;
+  notes?: string;
+}
+
+interface WaterStats {
+  total_today_ml: number;
+  daily_goal_ml: number;
+  goal_progress: number; // 0-1
+  avg_daily_ml: number;
+  days_goal_met: number;
+  days_tracked: number;
+}
+
+// =====================================================
+// Executor
+// =====================================================
+
+export class WaterTrackerExecutor implements IModExecutor {
+  readonly slug: ModSlug = "water-tracker";
+
+  async getData(tenantId: string): Promise<Record<string, unknown>> {
+    try {
+      const now = new Date();
+      const today = now.toISOString().split("T")[0];
+      const weekAgo = new Date(
+        now.getTime() - 7 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      const dailyGoal = 2500; // ml
+
+      const { data: entries, error } = await getServiceSupabase()
+        .from("exo_mod_data")
+        .select("*")
+        .eq("tenant_id", tenantId)
+        .eq("mod_slug", "water-tracker")
+        .gte("created_at", weekAgo)
+        .order("created_at", { ascending: false });
+
+      if (error) {
+        console.error("[WaterTracker] Fetch error:", error);
+        throw error;
+      }
+
+      const all = (entries || []).map((e) => ({
+        id: e.id,
+        ...(e.data as WaterEntry),
+        created_at: e.created_at,
+      }));
+
+      const todayEntries = all.filter((e) => e.created_at.startsWith(today));
+      const todayTotal = todayEntries.reduce((s, e) => s + e.amount_ml, 0);
+
+      return {
+        today: {
+          entries: todayEntries,
+          total_ml: todayTotal,
+          goal_ml: dailyGoal,
+          progress: Math.min(1, todayTotal / dailyGoal),
+        },
+        weekly: { entries: all, stats: this.calculateStats(all, dailyGoal) },
+      };
+    } catch (error) {
+      console.error("[WaterTracker] getData error:", error);
+      return {
+        today: { entries: [], total_ml: 0, goal_ml: 2500, progress: 0 },
+        weekly: { entries: [], stats: null },
+      };
+    }
+  }
+
+  async getInsights(tenantId: string): Promise<ModInsight[]> {
+    const insights: ModInsight[] = [];
+    const now = new Date();
+
+    try {
+      const data = await this.getData(tenantId);
+      const today = data.today as {
+        total_ml: number;
+        goal_ml: number;
+        progress: number;
+        entries: unknown[];
+      };
+      const stats = (data.weekly as { stats: WaterStats | null })?.stats;
+
+      if (today.entries.length === 0) {
+        insights.push({
+          type: "info",
+          title: "Stay Hydrated",
+          message: "No water logged today yet. Drink a glass now!",
+          action: { label: "Log Water", type: "button", onClick: "log_water" },
+          created_at: now.toISOString(),
+        });
+      } else if (today.progress >= 1) {
+        insights.push({
+          type: "success",
+          title: "Goal Met!",
+          message: `${today.total_ml} ml today — hydration goal reached!`,
+          created_at: now.toISOString(),
+        });
+      } else {
+        const remaining = today.goal_ml - today.total_ml;
+        insights.push({
+          type: "info",
+          title: "Keep Drinking",
+          message: `${today.total_ml}/${today.goal_ml} ml today. ${remaining} ml to go.`,
+          created_at: now.toISOString(),
+        });
+      }
+
+      if (stats && stats.days_tracked >= 3) {
+        const consistency = stats.days_goal_met / stats.days_tracked;
+        if (consistency >= 0.8) {
+          insights.push({
+            type: "success",
+            title: "Great Consistency",
+            message: `You've met your water goal ${stats.days_goal_met}/${stats.days_tracked} days. Keep it up!`,
+            created_at: now.toISOString(),
+          });
+        } else if (stats.avg_daily_ml < 1500) {
+          insights.push({
+            type: "warning",
+            title: "Low Intake",
+            message: `Averaging ${Math.round(stats.avg_daily_ml)} ml/day. Aim for at least 2000 ml.`,
+            created_at: now.toISOString(),
+          });
+        }
+      }
+
+      return insights;
+    } catch (error) {
+      console.error("[WaterTracker] getInsights error:", error);
+      return [
+        {
+          type: "warning",
+          title: "Error",
+          message: "Could not generate insights.",
+          created_at: now.toISOString(),
+        },
+      ];
+    }
+  }
+
+  async executeAction(
+    tenantId: string,
+    action: string,
+    params: Record<string, unknown>,
+  ): Promise<{ success: boolean; result?: unknown; error?: string }> {
+    try {
+      switch (action) {
+        case "log_water": {
+          const amount = (params.amount_ml as number) || 250;
+          if (amount <= 0 || amount > 5000) {
+            return {
+              success: false,
+              error: "Amount must be between 1 and 5000 ml",
+            };
+          }
+
+          const entry: WaterEntry = {
+            amount_ml: amount,
+            notes: params.notes as string | undefined,
+          };
+
+          const { data, error } = await getServiceSupabase()
+            .from("exo_mod_data")
+            .insert({
+              tenant_id: tenantId,
+              mod_slug: "water-tracker",
+              data: entry,
+            })
+            .select()
+            .single();
+
+          if (error) return { success: false, error: error.message };
+          return {
+            success: true,
+            result: { entry: data, message: `Logged ${amount} ml of water` },
+          };
+        }
+
+        case "get_today": {
+          const today = new Date().toISOString().split("T")[0];
+
+          const { data, error } = await getServiceSupabase()
+            .from("exo_mod_data")
+            .select("*")
+            .eq("tenant_id", tenantId)
+            .eq("mod_slug", "water-tracker")
+            .gte("created_at", today)
+            .order("created_at", { ascending: false });
+
+          if (error) return { success: false, error: error.message };
+
+          const total = (data || []).reduce(
+            (s, e) => s + ((e.data as WaterEntry).amount_ml || 0),
+            0,
+          );
+          return {
+            success: true,
+            result: { entries: data || [], total_ml: total },
+          };
+        }
+
+        default:
+          return { success: false, error: `Unknown action: ${action}` };
+      }
+    } catch (error) {
+      console.error("[WaterTracker] executeAction error:", error);
+      return { success: false, error: (error as Error).message };
+    }
+  }
+
+  getActions(): ModAction[] {
+    return [
+      {
+        slug: "log_water",
+        name: "Log Water",
+        description: "Record water intake",
+        params_schema: {
+          type: "object",
+          properties: {
+            amount_ml: {
+              type: "number",
+              default: 250,
+              description: "Amount in milliliters",
+            },
+            notes: { type: "string", description: "Optional notes" },
+          },
+        },
+      },
+      {
+        slug: "get_today",
+        name: "Get Today",
+        description: "Get today's water intake",
+        params_schema: { type: "object", properties: {} },
+      },
+    ];
+  }
+
+  private calculateStats(
+    entries: (WaterEntry & { created_at: string })[],
+    dailyGoal: number,
+  ): WaterStats {
+    if (entries.length === 0) {
+      return {
+        total_today_ml: 0,
+        daily_goal_ml: dailyGoal,
+        goal_progress: 0,
+        avg_daily_ml: 0,
+        days_goal_met: 0,
+        days_tracked: 0,
+      };
+    }
+
+    const byDay: Record<string, number> = {};
+    for (const e of entries) {
+      const day = e.created_at.split("T")[0];
+      byDay[day] = (byDay[day] || 0) + e.amount_ml;
+    }
+
+    const days = Object.keys(byDay);
+    const totalAll = Object.values(byDay).reduce((s, v) => s + v, 0);
+    const daysGoalMet = Object.values(byDay).filter(
+      (v) => v >= dailyGoal,
+    ).length;
+
+    const today = new Date().toISOString().split("T")[0];
+    const todayTotal = byDay[today] || 0;
+
+    return {
+      total_today_ml: todayTotal,
+      daily_goal_ml: dailyGoal,
+      goal_progress: Math.min(1, todayTotal / dailyGoal),
+      avg_daily_ml: Math.round(totalAll / days.length),
+      days_goal_met: daysGoalMet,
+      days_tracked: days.length,
+    };
+  }
+}

--- a/exoskull-app/lib/mods/index.ts
+++ b/exoskull-app/lib/mods/index.ts
@@ -2,23 +2,23 @@
 // MODS - User-facing Abilities & Extensions
 // =====================================================
 
-export * from './types';
+export * from "./types";
 
 // Mod definitions with capabilities and requirements
 export const MOD_DEFINITIONS = {
-  'sleep-tracker': {
-    slug: 'sleep-tracker' as const,
-    name: 'Sleep Tracker',
-    description: 'Track and analyze your sleep patterns with insights',
-    icon: '😴',
-    category: 'health' as const,
-    requires_rigs: ['oura', 'fitbit', 'apple-health'],
+  "sleep-tracker": {
+    slug: "sleep-tracker" as const,
+    name: "Sleep Tracker",
+    description: "Track and analyze your sleep patterns with insights",
+    icon: "😴",
+    category: "health" as const,
+    requires_rigs: ["oura", "fitbit", "apple-health"],
     config_schema: {
-      type: 'object',
+      type: "object",
       properties: {
-        goal_hours: { type: 'number', default: 8 },
-        bedtime_reminder: { type: 'boolean', default: true },
-        bedtime_target: { type: 'string', default: '22:30' },
+        goal_hours: { type: "number", default: 8 },
+        bedtime_reminder: { type: "boolean", default: true },
+        bedtime_target: { type: "string", default: "22:30" },
       },
     },
     capabilities: {
@@ -29,20 +29,20 @@ export const MOD_DEFINITIONS = {
     },
   },
 
-  'energy-monitor': {
-    slug: 'energy-monitor' as const,
-    name: 'Energy Monitor',
-    description: 'Track your energy levels throughout the day',
-    icon: '⚡',
-    category: 'health' as const,
-    requires_rigs: ['oura', 'fitbit'],
+  "energy-monitor": {
+    slug: "energy-monitor" as const,
+    name: "Energy Monitor",
+    description: "Track your energy levels throughout the day",
+    icon: "⚡",
+    category: "health" as const,
+    requires_rigs: ["oura", "fitbit"],
     config_schema: {
-      type: 'object',
+      type: "object",
       properties: {
         check_in_times: {
-          type: 'array',
-          items: { type: 'string' },
-          default: ['09:00', '14:00', '19:00'],
+          type: "array",
+          items: { type: "string" },
+          default: ["09:00", "14:00", "19:00"],
         },
       },
     },
@@ -54,19 +54,20 @@ export const MOD_DEFINITIONS = {
     },
   },
 
-  'focus-mode': {
-    slug: 'focus-mode' as const,
-    name: 'Focus Mode',
-    description: 'Block distractions and optimize your environment for deep work',
-    icon: '🎯',
-    category: 'productivity' as const,
-    requires_rigs: ['google-calendar', 'philips-hue'],
+  "focus-mode": {
+    slug: "focus-mode" as const,
+    name: "Focus Mode",
+    description:
+      "Block distractions and optimize your environment for deep work",
+    icon: "🎯",
+    category: "productivity" as const,
+    requires_rigs: ["google-calendar", "philips-hue"],
     config_schema: {
-      type: 'object',
+      type: "object",
       properties: {
-        duration_minutes: { type: 'number', default: 90 },
-        block_calendar: { type: 'boolean', default: true },
-        dim_lights: { type: 'boolean', default: true },
+        duration_minutes: { type: "number", default: 90 },
+        block_calendar: { type: "boolean", default: true },
+        dim_lights: { type: "boolean", default: true },
       },
     },
     capabilities: {
@@ -77,19 +78,23 @@ export const MOD_DEFINITIONS = {
     },
   },
 
-  'task-manager': {
-    slug: 'task-manager' as const,
-    name: 'Task Manager',
-    description: 'Unified task management synced with Google Tasks, Todoist, and Notion',
-    icon: '📋',
-    category: 'productivity' as const,
-    requires_rigs: ['google-workspace', 'todoist', 'notion'],
+  "task-manager": {
+    slug: "task-manager" as const,
+    name: "Task Manager",
+    description:
+      "Unified task management synced with Google Tasks, Todoist, and Notion",
+    icon: "📋",
+    category: "productivity" as const,
+    requires_rigs: ["google-workspace", "todoist", "notion"],
     config_schema: {
-      type: 'object',
+      type: "object",
       properties: {
-        default_project: { type: 'string' },
-        auto_prioritize: { type: 'boolean', default: true },
-        google_tasklist_id: { type: 'string', description: 'Google Task List ID (default: @default)' },
+        default_project: { type: "string" },
+        auto_prioritize: { type: "boolean", default: true },
+        google_tasklist_id: {
+          type: "string",
+          description: "Google Task List ID (default: @default)",
+        },
       },
     },
     capabilities: {
@@ -100,20 +105,20 @@ export const MOD_DEFINITIONS = {
     },
   },
 
-  'mood-tracker': {
-    slug: 'mood-tracker' as const,
-    name: 'Mood Tracker',
-    description: 'Daily mood check-ins and pattern analysis',
-    icon: '🎭',
-    category: 'wellbeing' as const,
+  "mood-tracker": {
+    slug: "mood-tracker" as const,
+    name: "Mood Tracker",
+    description: "Daily mood check-ins and pattern analysis",
+    icon: "🎭",
+    category: "wellbeing" as const,
     requires_rigs: [],
     config_schema: {
-      type: 'object',
+      type: "object",
       properties: {
         check_in_times: {
-          type: 'array',
-          items: { type: 'string' },
-          default: ['08:00', '20:00'],
+          type: "array",
+          items: { type: "string" },
+          default: ["08:00", "20:00"],
         },
       },
     },
@@ -125,24 +130,24 @@ export const MOD_DEFINITIONS = {
     },
   },
 
-  'habit-tracker': {
-    slug: 'habit-tracker' as const,
-    name: 'Habit Tracker',
-    description: 'Build and maintain positive habits with streak tracking',
-    icon: '🔥',
-    category: 'wellbeing' as const,
+  "habit-tracker": {
+    slug: "habit-tracker" as const,
+    name: "Habit Tracker",
+    description: "Build and maintain positive habits with streak tracking",
+    icon: "🔥",
+    category: "wellbeing" as const,
     requires_rigs: [],
     config_schema: {
-      type: 'object',
+      type: "object",
       properties: {
         habits: {
-          type: 'array',
+          type: "array",
           items: {
-            type: 'object',
+            type: "object",
             properties: {
-              name: { type: 'string' },
-              frequency: { type: 'string', enum: ['daily', 'weekly'] },
-              reminder_time: { type: 'string' },
+              name: { type: "string" },
+              frequency: { type: "string", enum: ["daily", "weekly"] },
+              reminder_time: { type: "string" },
             },
           },
           default: [],
@@ -157,22 +162,22 @@ export const MOD_DEFINITIONS = {
     },
   },
 
-  'spending-tracker': {
-    slug: 'spending-tracker' as const,
-    name: 'Spending Tracker',
-    description: 'Track and categorize your expenses automatically',
-    icon: '💰',
-    category: 'finance' as const,
-    requires_rigs: ['plaid'],
+  "spending-tracker": {
+    slug: "spending-tracker" as const,
+    name: "Spending Tracker",
+    description: "Track and categorize your expenses automatically",
+    icon: "💰",
+    category: "finance" as const,
+    requires_rigs: ["plaid"],
     config_schema: {
-      type: 'object',
+      type: "object",
       properties: {
-        budget_alerts: { type: 'boolean', default: true },
-        monthly_budget: { type: 'number' },
+        budget_alerts: { type: "boolean", default: true },
+        monthly_budget: { type: "number" },
         categories: {
-          type: 'array',
-          items: { type: 'string' },
-          default: ['food', 'transport', 'entertainment', 'utilities'],
+          type: "array",
+          items: { type: "string" },
+          default: ["food", "transport", "entertainment", "utilities"],
         },
       },
     },
@@ -180,6 +185,118 @@ export const MOD_DEFINITIONS = {
       insights: true,
       notifications: true,
       actions: false,
+      voice: true,
+    },
+  },
+  "exercise-logger": {
+    slug: "exercise-logger" as const,
+    name: "Exercise Logger",
+    description: "Log workouts, track activity types, duration, and intensity",
+    icon: "💪",
+    category: "health" as const,
+    requires_rigs: [],
+    config_schema: {
+      type: "object",
+      properties: {
+        weekly_goal_minutes: { type: "number", default: 150 },
+        favorite_activities: {
+          type: "array",
+          items: { type: "string" },
+          default: ["running", "gym", "walking"],
+        },
+      },
+    },
+    capabilities: {
+      insights: true,
+      notifications: true,
+      actions: true,
+      voice: true,
+    },
+  },
+
+  "food-logger": {
+    slug: "food-logger" as const,
+    name: "Food Logger",
+    description: "Track meals, calories, and macronutrients",
+    icon: "🍎",
+    category: "health" as const,
+    requires_rigs: [],
+    config_schema: {
+      type: "object",
+      properties: {
+        daily_calorie_goal: { type: "number", default: 2000 },
+        track_macros: { type: "boolean", default: false },
+      },
+    },
+    capabilities: {
+      insights: true,
+      notifications: true,
+      actions: true,
+      voice: true,
+    },
+  },
+
+  "water-tracker": {
+    slug: "water-tracker" as const,
+    name: "Water Tracker",
+    description: "Track daily water intake and stay hydrated",
+    icon: "💧",
+    category: "health" as const,
+    requires_rigs: [],
+    config_schema: {
+      type: "object",
+      properties: {
+        daily_goal_ml: { type: "number", default: 2500 },
+        reminder_interval_hours: { type: "number", default: 2 },
+      },
+    },
+    capabilities: {
+      insights: true,
+      notifications: true,
+      actions: true,
+      voice: true,
+    },
+  },
+
+  "social-tracker": {
+    slug: "social-tracker" as const,
+    name: "Social Tracker",
+    description: "Track social interactions and relationship health",
+    icon: "👥",
+    category: "wellbeing" as const,
+    requires_rigs: [],
+    config_schema: {
+      type: "object",
+      properties: {
+        weekly_goal_interactions: { type: "number", default: 5 },
+      },
+    },
+    capabilities: {
+      insights: true,
+      notifications: true,
+      actions: true,
+      voice: true,
+    },
+  },
+
+  journal: {
+    slug: "journal" as const,
+    name: "Journal",
+    description: "Daily journaling with mood tagging and reflection prompts",
+    icon: "📝",
+    category: "wellbeing" as const,
+    requires_rigs: [],
+    config_schema: {
+      type: "object",
+      properties: {
+        daily_prompt: { type: "boolean", default: true },
+        prompt_time: { type: "string", default: "21:00" },
+      },
+    },
+    capabilities: {
+      insights: true,
+      notifications: true,
+      actions: true,
       voice: true,
     },
   },
@@ -200,7 +317,7 @@ export function getAllModSlugs(): string[] {
 // Check if user has required rigs for a mod
 export function checkModRequirements(
   modSlug: string,
-  connectedRigs: string[]
+  connectedRigs: string[],
 ): { satisfied: boolean; missing: string[] } {
   const mod = MOD_DEFINITIONS[modSlug as ModSlugKey];
   if (!mod) {

--- a/exoskull-app/lib/mods/types.ts
+++ b/exoskull-app/lib/mods/types.ts
@@ -13,7 +13,12 @@ export type BuiltinModSlug =
   | "calendar-assistant"
   | "mood-tracker"
   | "habit-tracker"
-  | "spending-tracker";
+  | "spending-tracker"
+  | "exercise-logger"
+  | "food-logger"
+  | "water-tracker"
+  | "social-tracker"
+  | "journal";
 
 // Dynamic skills use custom-* prefix (e.g., "custom-water-tracker")
 export type ModSlug = BuiltinModSlug | `custom-${string}`;


### PR DESCRIPTION
## Summary
- 5 new mod executors: exercise-logger, food-logger, water-tracker, social-tracker, journal
- All use generic `exo_mod_data` table with JSONB — no new DB migrations needed
- Each implements full `IModExecutor` interface with insights, actions, and voice support
- Integration registry page at `/dashboard/settings/integrations` with rig connection status
- `GET /api/rigs` endpoint lists all available rigs with user connection info
- Sidebar updated with "Integracje" nav item
- 10 total executor implementations (was 5)

## Test plan
- [ ] Build passes (`npm run build` — 134 routes, 0 errors)
- [ ] `/dashboard/mods` shows all 12 mod templates
- [ ] Installing exercise-logger/food-logger/water-tracker/social-tracker/journal works
- [ ] `/dashboard/settings/integrations` loads available rigs grouped by category
- [ ] `GET /api/rigs` returns rig list with connection status
- [ ] Voice: "zaloguj trening 30 min bieganie" → exercise-logger executor fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)