### PR TITLE
feat: Sprint 7 — Skill verification pipeline

### DIFF
--- a/exoskull-app/app/api/cron/skill-health/route.ts
+++ b/exoskull-app/app/api/cron/skill-health/route.ts
@@ -1,0 +1,154 @@
+// =====================================================
+// CRON: /api/cron/skill-health
+// Runs sandbox health checks on all approved skills.
+// Revokes skills that fail 3 consecutive checks.
+// Schedule: daily at 03:30 UTC
+// =====================================================
+
+import { NextRequest, NextResponse } from "next/server";
+import { withCronGuard } from "@/lib/admin/cron-guard";
+import { getServiceSupabase } from "@/lib/supabase/service";
+import { runHealthCheck } from "@/lib/skills/verification/smoke-test";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+async function handler(_request: NextRequest) {
+  const supabase = getServiceSupabase();
+
+  // Fetch all approved, non-archived skills
+  const { data: skills, error: fetchError } = await supabase
+    .from("exo_generated_skills")
+    .select("id, tenant_id, slug, executor_code, security_audit")
+    .eq("approval_status", "approved")
+    .is("archived_at", null);
+
+  if (fetchError) {
+    console.error("[CRON] skill-health fetch error:", fetchError);
+    return NextResponse.json(
+      { error: "Failed to fetch skills", details: fetchError.message },
+      { status: 500 },
+    );
+  }
+
+  if (!skills || skills.length === 0) {
+    return NextResponse.json({
+      success: true,
+      checked: 0,
+      failed: 0,
+      revoked: 0,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  let checked = 0;
+  let failed = 0;
+  let revoked = 0;
+  const failures: string[] = [];
+
+  for (const skill of skills) {
+    checked++;
+
+    try {
+      const result = await runHealthCheck(
+        skill.executor_code,
+        skill.tenant_id,
+        skill.id,
+      );
+
+      const audit =
+        typeof skill.security_audit === "object" && skill.security_audit
+          ? (skill.security_audit as Record<string, unknown>)
+          : {};
+
+      const prevFailures =
+        typeof audit.consecutiveHealthFailures === "number"
+          ? audit.consecutiveHealthFailures
+          : 0;
+
+      if (!result.passed) {
+        failed++;
+        const newFailCount = prevFailures + 1;
+
+        console.warn(
+          `[CRON] skill-health FAIL: ${skill.slug} (${newFailCount} consecutive)`,
+          result.errors,
+        );
+
+        // 3 consecutive failures → revoke
+        if (newFailCount >= 3) {
+          await supabase
+            .from("exo_generated_skills")
+            .update({
+              approval_status: "revoked",
+              rejection_reason: `Auto-revoked: ${newFailCount} consecutive health check failures. Last errors: ${result.errors.join("; ")}`,
+              security_audit: {
+                ...audit,
+                consecutiveHealthFailures: newFailCount,
+                lastHealthCheck: new Date().toISOString(),
+                lastHealthErrors: result.errors,
+              },
+              last_audit_at: new Date().toISOString(),
+            })
+            .eq("id", skill.id);
+
+          revoked++;
+          failures.push(`${skill.slug} (REVOKED after ${newFailCount} fails)`);
+        } else {
+          await supabase
+            .from("exo_generated_skills")
+            .update({
+              security_audit: {
+                ...audit,
+                consecutiveHealthFailures: newFailCount,
+                lastHealthCheck: new Date().toISOString(),
+                lastHealthErrors: result.errors,
+              },
+              last_audit_at: new Date().toISOString(),
+            })
+            .eq("id", skill.id);
+
+          failures.push(`${skill.slug} (fail ${newFailCount}/3)`);
+        }
+      } else {
+        // Passed — reset consecutive failure counter
+        if (prevFailures > 0) {
+          await supabase
+            .from("exo_generated_skills")
+            .update({
+              security_audit: {
+                ...audit,
+                consecutiveHealthFailures: 0,
+                lastHealthCheck: new Date().toISOString(),
+                lastHealthErrors: [],
+              },
+              last_audit_at: new Date().toISOString(),
+            })
+            .eq("id", skill.id);
+        }
+      }
+    } catch (error) {
+      console.error(
+        `[CRON] skill-health error on ${skill.slug}:`,
+        (error as Error).message,
+      );
+      failures.push(`${skill.slug} (exception: ${(error as Error).message})`);
+      failed++;
+    }
+  }
+
+  console.log(
+    `[CRON] skill-health complete: ${checked} checked, ${failed} failed, ${revoked} revoked`,
+  );
+
+  return NextResponse.json({
+    success: true,
+    checked,
+    failed,
+    revoked,
+    failures,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+export const GET = withCronGuard({ name: "skill-health" }, handler);

--- a/exoskull-app/lib/skills/types.ts
+++ b/exoskull-app/lib/skills/types.ts
@@ -68,10 +68,18 @@ export interface GeneratedSkill {
 // Skill Generation
 // =====================================================
 
+export type SkillGeneratorModel =
+  | "claude-sonnet"
+  | "codex"
+  | "gemini-flash"
+  | "auto";
+
 export interface SkillGenerationRequest {
   tenant_id: string;
   description: string;
   source: "user_request" | "gap_detection" | "pattern_match";
+  /** Which AI model to use for code generation. Defaults to "auto" (router decides). */
+  model?: SkillGeneratorModel;
 }
 
 export interface SkillGenerationResult {

--- a/exoskull-app/lib/skills/verification/smoke-test.ts
+++ b/exoskull-app/lib/skills/verification/smoke-test.ts
@@ -1,0 +1,123 @@
+/**
+ * Skill Smoke Test — Verify generated code actually works.
+ *
+ * After AI generates code and it passes static/schema/security validation,
+ * we run it in the sandbox and call getActions() + getData() to verify
+ * it doesn't crash. This catches runtime errors that static analysis misses.
+ *
+ * Pattern inspired by OpenClaw probe-based verification + E2B execute-verify loop.
+ */
+
+import { executeInSandbox } from "../sandbox/restricted-function";
+import { SkillExecutionResult } from "../types";
+
+export interface SmokeTestResult {
+  passed: boolean;
+  getActionsResult: SkillExecutionResult | null;
+  getDataResult: SkillExecutionResult | null;
+  errors: string[];
+  durationMs: number;
+}
+
+/**
+ * Run smoke test on generated skill code.
+ * Executes getActions() and getData() in sandbox to verify basic functionality.
+ *
+ * @param code - The generated TypeScript code
+ * @param tenantId - Tenant ID for data context
+ * @param skillId - Skill ID for logging
+ */
+export async function runSmokeTest(
+  code: string,
+  tenantId: string,
+  skillId: string,
+): Promise<SmokeTestResult> {
+  const start = performance.now();
+  const errors: string[] = [];
+
+  // Test 1: getActions() — must return an array (pure function, no DB needed)
+  const actionsResult = await executeInSandbox(
+    {
+      tenant_id: tenantId,
+      skill_id: skillId,
+      method: "getActions",
+      args: [],
+    },
+    code,
+  );
+
+  if (!actionsResult.success) {
+    errors.push(`getActions() failed: ${actionsResult.error}`);
+  } else if (!Array.isArray(actionsResult.result)) {
+    errors.push(
+      `getActions() must return array, got ${typeof actionsResult.result}`,
+    );
+  }
+
+  // Test 2: getData() — must return an object (may query DB, empty data is OK)
+  const dataResult = await executeInSandbox(
+    {
+      tenant_id: tenantId,
+      skill_id: skillId,
+      method: "getData",
+      args: [],
+    },
+    code,
+  );
+
+  if (!dataResult.success) {
+    errors.push(`getData() failed: ${dataResult.error}`);
+  } else if (
+    dataResult.result === null ||
+    typeof dataResult.result !== "object"
+  ) {
+    errors.push(
+      `getData() must return object, got ${typeof dataResult.result}`,
+    );
+  }
+
+  const durationMs = Math.round(performance.now() - start);
+
+  return {
+    passed: errors.length === 0,
+    getActionsResult: actionsResult,
+    getDataResult: dataResult,
+    errors,
+    durationMs,
+  };
+}
+
+/**
+ * Run health check on an approved skill — same as smoke test but also tests getInsights().
+ * Used by CRON job to verify skills still work over time.
+ */
+export async function runHealthCheck(
+  code: string,
+  tenantId: string,
+  skillId: string,
+): Promise<SmokeTestResult> {
+  const baseResult = await runSmokeTest(code, tenantId, skillId);
+
+  // Additionally test getInsights()
+  const insightsResult = await executeInSandbox(
+    {
+      tenant_id: tenantId,
+      skill_id: skillId,
+      method: "getInsights",
+      args: [],
+    },
+    code,
+  );
+
+  if (!insightsResult.success) {
+    baseResult.errors.push(`getInsights() failed: ${insightsResult.error}`);
+    baseResult.passed = false;
+  } else if (!Array.isArray(insightsResult.result)) {
+    baseResult.errors.push(
+      `getInsights() must return array, got ${typeof insightsResult.result}`,
+    );
+    baseResult.passed = false;
+  }
+
+  return baseResult;
+}


### PR DESCRIPTION
## Summary
- **Smoke test**: Runtime verification (getActions + getData in sandbox) between security audit and DB insert. Failed skills get error feedback and retry (max 3)
- **Model choice**: Users select AI model for code generation: `claude-sonnet` / `codex` / `gemini-flash` / `auto` (router decides)
- **Health check CRON**: Daily `/api/cron/skill-health` re-runs smoke tests on all approved skills. Auto-revokes after 3 consecutive failures

## Files changed (5)
- `lib/skills/verification/smoke-test.ts` — NEW: runSmokeTest() + runHealthCheck()
- `lib/skills/generator/skill-generator.ts` — Step 5.5 smoke test, model routing
- `lib/skills/types.ts` — SkillGeneratorModel type
- `app/api/skills/generate/route.ts` — Accept `model` param
- `app/api/cron/skill-health/route.ts` — NEW: Daily health check CRON

## Test plan
- [ ] Build passes (`npm run build` — verified locally)
- [ ] POST `/api/skills/generate` with `{ description: "...", model: "codex" }` returns `generated_by: "openai-codex"`
- [ ] Generated skill that crashes at runtime triggers smoke test failure + retry
- [ ] CRON `/api/cron/skill-health` checks approved skills and revokes after 3 fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)